### PR TITLE
MAC calculation function, c_ref = MAC and small bug fixed in example .py

### DIFF
--- a/aerosandbox/geometry/airplane.py
+++ b/aerosandbox/geometry/airplane.py
@@ -62,7 +62,7 @@ class Airplane(AeroSandboxObject):
 
         self.s_ref = main_wing.area()
         self.b_ref = main_wing.span()
-        self.c_ref = main_wing.mean_geometric_chord()
+        self.c_ref = main_wing.mean_aerodynamic_chord()
 
     def set_paneling_everywhere(self, n_chordwise_panels, n_spanwise_panels):
         # Sets the chordwise and spanwise paneling everywhere to a specified init_val.

--- a/aerosandbox/geometry/wing.py
+++ b/aerosandbox/geometry/wing.py
@@ -149,6 +149,87 @@ class Wing(AeroSandboxObject):
         """
         return self.area() / self.span()
 
+    def mean_aerodynamic_chord(self):
+        """
+        Returns the mean aerodynamc chord of the wing
+        The method used below accounts only for cases where LE and TE of the slice are straight lines
+        For further development, when LE or TE would be represented as a function of y coordinate,
+        integration method could be incorporated
+        The current method uses standard formulas for MAC as a function of tapper_ratio
+        """
+        area = 0
+        sum_dMAC_dA = 0
+
+        for i, xsec in enumerate(self.xsecs):
+
+            if not i == len(self.xsecs) - 1:
+                c_r = xsec.chord
+                c_t = self.xsecs[i+1].chord
+                y_r = xsec.y_le
+                y_t = self.xsecs[i+1].y_le
+
+                tapper_ratio = c_t / c_r
+                d_area = (c_r + c_t) * (y_t - y_r) / 2
+                MAC_i = (2/3) * c_r * ((1 + tapper_ratio + tapper_ratio ** 2) / (1 + tapper_ratio))
+                area = area + d_area
+                sum_dMAC_dA = d_area * MAC_i + sum_dMAC_dA
+
+        MAC = sum_dMAC_dA / area
+
+        return MAC
+
+    def mean_aerodynamic_chord_x(self):
+        """
+        Returns the mean aerodynamc chord x LE position
+        Bases on the same assumptions as mean_aerodynamic_chord
+        """
+        area = 0
+        sum_dx_dA = 0
+        for i, xsec in enumerate(self.xsecs):
+
+            if not i == len(self.xsecs) - 1:
+                c_r = xsec.chord
+                c_t = self.xsecs[i+1].chord
+                y_r = xsec.y_le
+                y_t = self.xsecs[i+1].y_le
+                x_r = xsec.x_le
+                x_t = self.xsecs[i + 1].x_le
+                tapper_ratio = c_t / c_r
+                d_area = (c_r + c_t) * (y_t - y_r) / 2
+                area = area + d_area
+
+                x_mac = x_r + (x_t - x_r) * (1 + 2 * tapper_ratio) / (3 + 3 * tapper_ratio)
+                sum_dx_dA = d_area * x_mac + sum_dx_dA
+
+        x_mac = sum_dx_dA / area
+
+        return x_mac
+
+    def mean_aerodynamic_chord_y(self):
+        """
+        Returns the mean aerodynamic chord y LE position
+        Bases on the same assumptions as mean_aerodynamic_chord
+        """
+        area = 0
+        sum_dy_dA = 0
+
+        for i, xsec in enumerate(self.xsecs):
+
+            if not i == len(self.xsecs) - 1:
+                c_r = xsec.chord
+                c_t = self.xsecs[i+1].chord
+                y_r = xsec.y_le
+                y_t = self.xsecs[i+1].y_le
+                tapper_ratio = c_t / c_r
+                d_area = (c_r + c_t) * (y_t - y_r) / 2
+                area = area + d_area
+
+                y_mac = y_r + (y_t - y_r)*(1 + 2 * tapper_ratio) / (3 + 3 * tapper_ratio)
+                sum_dy_dA = d_area * y_mac + sum_dy_dA
+
+        y_mac = sum_dy_dA / area
+        return y_mac
+
     def mean_twist_angle(self):
         """
         Returns the mean twist angle (in degrees) of the wing, weighted by span.

--- a/aerosandbox/geometry/wing.py
+++ b/aerosandbox/geometry/wing.py
@@ -151,11 +151,11 @@ class Wing(AeroSandboxObject):
 
     def mean_aerodynamic_chord(self):
         """
-        Returns the mean aerodynamc chord of the wing
+        Returns the mean aerodynamic chord of the wing
         The method used below accounts only for cases where LE and TE of the slice are straight lines
         For further development, when LE or TE would be represented as a function of y coordinate,
         integration method could be incorporated
-        The current method uses standard formulas for MAC as a function of tapper_ratio
+        The current method uses standard formulas for MAC as a function of taper_ratio
         """
         area = 0
         sum_dMAC_dA = 0
@@ -168,9 +168,9 @@ class Wing(AeroSandboxObject):
                 y_r = xsec.y_le
                 y_t = self.xsecs[i+1].y_le
 
-                tapper_ratio = c_t / c_r
+                taper_ratio = c_t / c_r
                 d_area = (c_r + c_t) * (y_t - y_r) / 2
-                MAC_i = (2/3) * c_r * ((1 + tapper_ratio + tapper_ratio ** 2) / (1 + tapper_ratio))
+                MAC_i = (2/3) * c_r * ((1 + taper_ratio + taper_ratio ** 2) / (1 + taper_ratio))
                 area = area + d_area
                 sum_dMAC_dA = d_area * MAC_i + sum_dMAC_dA
 
@@ -178,39 +178,13 @@ class Wing(AeroSandboxObject):
 
         return MAC
 
-    def mean_aerodynamic_chord_x(self):
+    def mean_aerodynamic_chord_coord(self):
         """
-        Returns the mean aerodynamc chord x LE position
+        Returns the mean aerodynamic chord x and y LE position
         Bases on the same assumptions as mean_aerodynamic_chord
         """
         area = 0
         sum_dx_dA = 0
-        for i, xsec in enumerate(self.xsecs):
-
-            if not i == len(self.xsecs) - 1:
-                c_r = xsec.chord
-                c_t = self.xsecs[i+1].chord
-                y_r = xsec.y_le
-                y_t = self.xsecs[i+1].y_le
-                x_r = xsec.x_le
-                x_t = self.xsecs[i + 1].x_le
-                tapper_ratio = c_t / c_r
-                d_area = (c_r + c_t) * (y_t - y_r) / 2
-                area = area + d_area
-
-                x_mac = x_r + (x_t - x_r) * (1 + 2 * tapper_ratio) / (3 + 3 * tapper_ratio)
-                sum_dx_dA = d_area * x_mac + sum_dx_dA
-
-        x_mac = sum_dx_dA / area
-
-        return x_mac
-
-    def mean_aerodynamic_chord_y(self):
-        """
-        Returns the mean aerodynamic chord y LE position
-        Bases on the same assumptions as mean_aerodynamic_chord
-        """
-        area = 0
         sum_dy_dA = 0
 
         for i, xsec in enumerate(self.xsecs):
@@ -220,15 +194,23 @@ class Wing(AeroSandboxObject):
                 c_t = self.xsecs[i+1].chord
                 y_r = xsec.y_le
                 y_t = self.xsecs[i+1].y_le
-                tapper_ratio = c_t / c_r
+                x_r = xsec.x_le
+                x_t = self.xsecs[i + 1].x_le
+                taper_ratio = c_t / c_r
                 d_area = (c_r + c_t) * (y_t - y_r) / 2
                 area = area + d_area
 
-                y_mac = y_r + (y_t - y_r)*(1 + 2 * tapper_ratio) / (3 + 3 * tapper_ratio)
+                x_mac = x_r + (x_t - x_r) * (1 + 2 * taper_ratio) / (3 + 3 * taper_ratio)
+                sum_dx_dA = d_area * x_mac + sum_dx_dA
+                y_mac = y_r + (y_t - y_r)*(1 + 2 * taper_ratio) / (3 + 3 * taper_ratio)
                 sum_dy_dA = d_area * y_mac + sum_dy_dA
 
+
+        x_mac = sum_dx_dA / area
         y_mac = sum_dy_dA / area
-        return y_mac
+
+        return [x_mac, y_mac]
+
 
     def mean_twist_angle(self):
         """

--- a/examples/conventional/buildup_conventional_analysis_point.py
+++ b/examples/conventional/buildup_conventional_analysis_point.py
@@ -150,6 +150,8 @@ print("CD:", ap_sol.CD)
 # print("CY:", ap_sol.CY)
 # print("Cl:", ap_sol.Cl)
 print("Cm:", ap_sol.Cm)
+
+
 # print("Cn:", ap_sol.Cn)
 
 # Answer you should get: (XFLR5)

--- a/examples/conventional/casvlm1_conventional_analysis_alpha_sweep.py
+++ b/examples/conventional/casvlm1_conventional_analysis_alpha_sweep.py
@@ -56,7 +56,7 @@ airplane = Airplane(
                     chord=0.18,
                     twist=2,  # degrees
                     airfoil=Airfoil(name="naca4412"),
-                    control_surface_type='symmetric_problem',
+                    control_surface_type='symmetric',
                     # Flap # Control surfaces are applied between a given XSec and the next one.
                     control_surface_deflection=0,  # degrees
                     control_surface_hinge_point=0.75  # as chord fraction
@@ -96,7 +96,7 @@ airplane = Airplane(
                     chord=0.1,
                     twist=-10,
                     airfoil=Airfoil(name="naca0012"),
-                    control_surface_type='symmetric_problem',  # Elevator
+                    control_surface_type='symmetric',  # Elevator
                     control_surface_deflection=0,
                     control_surface_hinge_point=0.75
                 ),
@@ -124,7 +124,7 @@ airplane = Airplane(
                     chord=0.1,
                     twist=0,
                     airfoil=Airfoil(name="naca0012"),
-                    control_surface_type='symmetric_problem',  # Rudder
+                    control_surface_type='symmetric',  # Rudder
                     control_surface_deflection=0,
                     control_surface_hinge_point=0.75
                 ),

--- a/studies/autodiff_for_design_resources.md
+++ b/studies/autodiff_for_design_resources.md
@@ -8,7 +8,7 @@ So there are two kind of paths that you can use that both arrive at the whole au
 
 The CS-like path basically is: This is how you would efficiently find the derivative of a series of operations  using the chain rule. There's a way to do this "forward" and "backward" - oh and hey, design optimization is a prime use-case for this backwards way.
 
-The Math/Physics-like path is probably most related to adjoint methods for PDEs, though we only occasionally use PDEs in our aircraft design optimization work (usually we have some simplified model that approximates this). In the world of PDEs, there's something called an adjoint method that lets you effectively "differentiate backwards" through a PDE by exploiting some properties when you differentiate the governing equation. That turns out to be very useful for design optimization! Oh, and how would we actually efficiently implement this in code?
+The Math/Physics-like path is probably most related to adjoint methods for PDEs, though we only occasionally directly use PDEs in our aircraft design optimization work (usually we have some surrogate model that approximates this for speed reasons). In the world of PDEs, an adjoint method that lets you effectively "differentiate backwards" through a PDE by exploiting some properties of residuals when you differentiate the governing equation. That turns out to be very useful for design optimization! Oh, and how would we actually efficiently implement this in code?
 
 I think the best way to learn this is to bark up both trees and try to have them meet somewhere in the middle.
 


### PR DESCRIPTION
Added 3 functions in wing.py:

mean_aerodynamic_chord - returns wing's MAC
mean_aerodynamic_chord_x - returns wing's MAC x coordinate (LE)
mean_aerodynamic_chord_y - returns wing's MAC y coordinate (LE)

Changed c_ref to be c_ref = MAC; instead of mean_geometric_chord

Fixed a minor bug in one of the examples. String input to wing symmetry/asymmetry of control surfaces was invalid. Now it works fine

Hope you will find it useful, 

Szymon