### PR TITLE
Correcting Torenbeek

### DIFF
--- a/aerosandbox/library/weights/torenbeek_weights.py
+++ b/aerosandbox/library/weights/torenbeek_weights.py
@@ -15,7 +15,8 @@ def mass_wing_simple(
         main_gear_mounted_to_wing: bool = True,
 ) -> float:
     """
-    Computes the mass of a wing of an aircraft, according to Torenbeek's "Synthesis of Subsonic Airplane Design",
+    Computes the mass of a wing of an aircraft, according to Torenbeek's "Synthesis of Subsonic 
+    Airplane Design",
 
     This is the simple version of the wing weight model, which is found in:
     Section 8.4: Weight Prediction Data and Methods
@@ -264,13 +265,16 @@ def mass_spoilers_and_speedbrakes(
     
     Returns the mass of the spoilers and speed brakes
 
-    N.B. the weight comes out way too heavy comes out as 30% of the weight of the wing. that is 
-    unacceptable and needs correction.
+    N.B. the weight estimation using the 12.2 kg/m^2 figure comes out too high if using
+    the wing as a referenced area. Reduced to 1.5% of the basic wing mass.
     '''
-    mass_spoilers_and_speedbrakes = np.softmax(
-                                                12.2 * wing.area(),
-                                                0.015 * mass_basic_wing
-                                                )
+    #mass_spoilers_and_speedbrakes = np.softmax(
+    #                                            12.2 * wing.area(),
+    #                                            0.015 * mass_basic_wing
+    #                                            )
+    
+    mass_spoilers_and_speedbrakes = 0.015 * mass_basic_wing
+    
     return mass_spoilers_and_speedbrakes
 
 def mass_wing(

--- a/aerosandbox/library/weights/torenbeek_weights.py
+++ b/aerosandbox/library/weights/torenbeek_weights.py
@@ -58,6 +58,221 @@ def mass_wing_simple(
     )
 
 
+def mass_high_lift(
+        wing: asb.Wing,
+        max_airspeed_for_flaps: float,
+        flap_deflection_angle: float = 30,
+        k_f1: float = 1.0,
+        k_f2: float = 1.0
+        ):
+    '''
+    The function mass_high_lift() is designed to estimate the weight of the high-lift devices 
+    on an airplane wing. It uses Torenbeek's method, which is based on multiple factors 
+    like wing design and flap deflection.
+
+    Args:
+
+        wing, an instance of AeroSandbox's Wing class,
+        
+        max_airspeed_for_flaps, the maximum airspeed at which the flaps can be deployed, 
+        
+        flap_deflection_angle, the angle to which the flaps can be deflected (default value is 30 degrees).
+    
+        k_f1, configuration factor 1, with values:
+                = 1.0  for single slotted; double slotted, fixed hinge
+                = 1.15 for double: slotted, 4-bar movement; single slotted Fowler
+                = 1.3  for double slotted Fowler 
+                = 1.45 for triple slotted Fowler
+
+        k_f2, configuration factor 2, with values:
+                = 1.0  for slotted flaps with fixed vane 
+                = 1.25 for double slotted flaps with "variable geometry", i.e. ex- tending 
+                           flaps with separately moving vanes or auxiliary flaps
+    
+    Returns mass of the high lift system as float
+    '''
+    # S_flaps represents the total area of the control surfaces (flaps) on the wing.
+    S_flaps = wing.control_surface_area()
+
+    # Wing span
+    span = wing.span()
+
+    # Sweep at 50% chord
+    sweep_half_chord = wing.mean_sweep_angle(x_nondim=0.5)
+    cos_sweep_half_chord = np.cosd(sweep_half_chord)
+
+    # span_structural is the "structural" wing span, which takes into account the wing's sweep angle.
+    span_structural = span / cos_sweep_half_chord
+
+    # Airfoil thickness over chord ratio at root
+    root_t_over_c = wing.xsecs[0].airfoil.max_thickness()
+
+    # Torenbeek Eq. C-10
+    k_f = k_f1 * k_f2
+
+    mass_trailing_edge_flaps = S_flaps * (
+            2.706 * k_f *
+            (S_flaps * span_structural) ** (3 / 16) *
+            (
+                    (max_airspeed_for_flaps / 100) ** 2 *
+                    np.sind(flap_deflection_angle) *
+                    np.cosd(wing.mean_sweep_angle(x_nondim=1)) /
+                    root_t_over_c
+            ) ** (3 / 4)
+    )
+
+    mass_leading_edge_devices = 0
+
+    mass_high_lift_devices = mass_trailing_edge_flaps + mass_leading_edge_devices
+
+    return mass_high_lift_devices
+
+def mass_basic_wing_structure(
+        wing: asb.Wing,
+        design_mass_TOGW: float,
+        ultimate_load_factor: float,
+        suspended_mass: float,
+        never_exceed_airspeed: float,
+        main_gear_mounted_to_wing: bool = True,
+        strut_y_location: float = None,
+        k_e: float = 0.95,
+        return_dict: bool = False,
+) -> Union[float, Dict[str, float]]:
+    """
+    Computes the mass of the basic structure of the wing of an aircraft, according to 
+    Torenbeek's "Synthesis of Subsonic Airplane Design", 1976, Appendix C: "Prediction 
+    of Wing Structural Weight". This is the basic wing structure without moveables like spoilers, 
+    high lift devices etc
+
+    Likely more accurate than the Raymer wing weight models.
+
+    Args:
+
+        wing: The wing object.
+
+        design_mass_TOGW: The design takeoff gross weight of the entire aircraft [kg].
+
+        ultimate_load_factor: The ultimate load factor of the aircraft. 1.5x the limit load factor.
+
+        suspended_mass: The mass of the aircraft that is suspended from the wing [kg]. It should exclude 
+        any wing attachments that are not part of the wing structure.
+
+        never_exceed_airspeed: The never-exceed airspeed of the aircraft [m/s]. Used for flutter calculations.
+
+        main_gear_mounted_to_wing: Whether the main gear is mounted to the wing structure.
+
+        strut_y_location: The y-location of the strut (if any), relative to the wing's leading edge [m]. If None,
+        it is assumed that there is no strut (i.e., the wing is a cantilever beam).
+
+        k_e: represents weight knockdowns due to bending moment relief from engines mounted in front of elastic axis.
+        see Torenbeek unlabeled equations, between C-3 and C-4. 
+                k_e = 1.0 if engines not wing mounted, 
+                k_e = 0.95 (default) two wing mounted engines in front of the elastic axis and 
+                k_e = 0.90 four wing-mounted engines in front of the elastic axis
+
+        return_dict: Whether to return a dictionary of all the intermediate values, or just the final mass. Defaults
+        to False, which returns just the final mass.
+
+    Returns: If return_dict is False (default), returns a single value: the mass of the basic wing [kg]. If return_dict is
+    True, returns a dictionary of all the intermediate values.
+
+    """
+
+    # Wing span
+    span = wing.span()
+
+    # Sweep at 50% chord
+    sweep_half_chord = wing.mean_sweep_angle(x_nondim=0.5)
+    cos_sweep_half_chord = np.cosd(sweep_half_chord)
+
+    # Structural wing span
+    span_structural = span / cos_sweep_half_chord
+
+    # Airfoil thickness over chord ratio at root
+    root_t_over_c = wing.xsecs[0].airfoil.max_thickness()
+
+    # Torenbeek Eq. C-2
+    # `k_no` represents penalties due to skin joints, non-tapered skin, minimum gauge, etc.
+    k_no = 1 + (1.905 / span_structural) ** 0.5
+
+    # Torenbeek Eq. C-3
+    # `k_lambda` represents penalties due to taper ratio
+    k_lambda = (1 + wing.taper_ratio()) ** 0.4
+
+    # `k_uc` represents weight knockdowns due to undercarriage.
+    k_uc = 1 if main_gear_mounted_to_wing else 0.95
+
+    # Torenbeek Eq. C-4
+    # `k_st` represents weight excrescence due to structural stiffness against flutter.
+    k_st = (
+            1 +
+            9.06e-4 * (
+                    (span * np.cosd(wing.mean_sweep_angle(x_nondim=0))) ** 3 /
+                    design_mass_TOGW
+            ) * (
+                    never_exceed_airspeed / 100 / root_t_over_c
+            ) ** 2 *
+            cos_sweep_half_chord
+    )
+ 
+    # Torenbeek Eq. C-5
+    # `k_b` represents weight knockdowns due to bending moment relief from strut location.
+    if strut_y_location is None:
+        k_b = 1
+    else:
+        k_b = 1 - (strut_y_location / (wing.span() / 2)) ** 2
+
+    ### Use all the above to compute the basic wing structural mass
+    mass_wing_basic = (
+            4.58e-3 *
+            k_no *
+            k_lambda *
+            k_e *
+            k_uc *
+            k_st *
+            (
+                    k_b * ultimate_load_factor * (0.8 * suspended_mass + 0.2 * design_mass_TOGW)
+            ) ** 0.55 *
+            span ** 1.675 *
+            root_t_over_c ** -0.45 *
+            cos_sweep_half_chord ** -1.325
+    )
+
+    if return_dict:
+        return locals()
+    else:
+        return mass_wing_basic
+
+
+def mass_spoilers_and_speedbrakes(
+    wing: asb.Wing,
+    mass_basic_wing: float
+    ):
+    '''
+    The function mass_spoilers_and_speedbrakes() estimates the weight of the spoilers and speedbrakes
+    according to Torenbeek's "Synthesis of Subsonic Airplane Design", 1976, Appendix C: "Prediction 
+    of Wing Structural Weight".
+
+    N.B. the weight is coming out unrealistic and approx. 20-30% of the weight of the wing. This needs 
+    a correction. It uses normally the 12.2 kg/m^2 wing area.
+
+    Args:
+        
+        wing: an instance of AeroSandbox's Wing class.
+        
+        mass_basic_wing: the basic weight of the wing (without spoilers, speedbrakes, flaps, slats).
+    
+    Returns the mass of the spoilers and speed brakes
+
+    N.B. the weight comes out way too heavy comes out as 30% of the weight of the wing. that is 
+    unacceptable and needs correction.
+    '''
+    mass_spoilers_and_speedbrakes = np.softmax(
+                                                12.2 * wing.area(),
+                                                0.015 * mass_basic_wing
+                                                )
+    return mass_spoilers_and_speedbrakes
+
 def mass_wing(
         wing: asb.Wing,
         design_mass_TOGW: float,
@@ -72,7 +287,7 @@ def mass_wing(
 ) -> Union[float, Dict[str, float]]:
     """
     Computes the mass of a wing of an aircraft, according to Torenbeek's "Synthesis of Subsonic Airplane Design",
-    1976, Appendix C: "Prediction of Wing Structural Weight" (PDF page 451).
+    1976, Appendix C: "Prediction of Wing Structural Weight".
 
     Likely more accurate than the Raymer wing weight models.
 
@@ -106,108 +321,39 @@ def mass_wing(
 
     """
 
-    # Wing span
-    span = wing.span()
-
-    # Sweep at 50% chord
-    sweep_half_chord = wing.mean_sweep_angle(x_nondim=0.5)
-    cos_sweep_half_chord = np.cosd(sweep_half_chord)
-
-    # Structural wing span
-    span_structural = span / cos_sweep_half_chord
-
-    # Airfoil thickness over chord ratio at root
-    root_t_over_c = wing.xsecs[0].airfoil.max_thickness()
-
-    # Torenbeek Eq. C-2
-    # `k_no` represents penalties due to skin joints, non-tapered skin, minimum gauge, etc.
-    k_no = 1 + (1.905 / span_structural) ** 0.5
-
-    # Torenbeek Eq. C-3
-    # `k_lambda` represents penalties due to taper ratio
-    k_lambda = (1 + wing.taper_ratio()) ** 0.4
-
-    # Torenbeek unlabeled equations, between C-3 and C-4
-    # `k_e` represents weight knockdowns due to bending moment relief from engines mounted in front of elastic axis.
-    k_e = 1
-
-    # `k_uc` represents weight knockdowns due to undercarriage.
-    k_uc = 1 if main_gear_mounted_to_wing else 0.95
-
-    # Torenbeek Eq. C-4
-    # `k_st` represents weight excrescence due to structural stiffness against flutter.
-    k_st = (
-            1 +
-            9.06e-4 * (
-                    (span * np.cosd(wing.mean_sweep_angle(x_nondim=0))) ** 3 /
-                    design_mass_TOGW
-            ) * (
-                    never_exceed_airspeed / 100 / root_t_over_c
-            ) ** 2 *
-            cos_sweep_half_chord
-    )
-
-    # Torenbeek Eq. C-5
-    # `k_b` represents weight knockdowns due to bending moment relief from strut location.
-    if strut_y_location is None:
-        k_b = 1
-    else:
-        k_b = 1 - (strut_y_location / (wing.span() / 2)) ** 2
-
-    ### Use all the above to compute the basic wing structural mass
-    mass_basic_wing_structure = (
-            4.58e-3 *
-            k_no *
-            k_lambda *
-            k_e *
-            k_uc *
-            k_st *
-            (
-                    k_b * ultimate_load_factor * (0.8 * suspended_mass + 0.2 * design_mass_TOGW)
-            ) ** 0.55 *
-            span ** 1.675 *
-            root_t_over_c ** -0.45 *
-            cos_sweep_half_chord ** -1.325
-    )
-
-    S_flaps = wing.control_surface_area()
-
-    # Torenbeek Eq. C-10
-    k_f1 = 1  # single-slotted; double slotted, fixed hinge # TODO add details
-    k_f2 = 1  # slotted flaps with fixed vane # TODO add details
-
-    k_f = k_f1 * k_f2
-
-    mass_trailing_edge_flaps = S_flaps * (
-            2.706 * k_f *
-            (S_flaps * span_structural) ** (3 / 16) *
-            (
-                    (max_airspeed_for_flaps / 100) ** 2 *
-                    np.sind(flap_deflection_angle) *
-                    np.cosd(wing.mean_sweep_angle(x_nondim=1)) /
-                    root_t_over_c
-            ) ** (3 / 4)
-    )
-
-    mass_leading_edge_devices = 0
-
-    mass_high_lift_devices = mass_trailing_edge_flaps + mass_leading_edge_devices
-
-    # mass_spoilers_and_speedbrakes = np.softmax(
-    #     12.2 * wing.area() * spoilers_and_speedbrakes_area_fraction,
-    #     0.015 * mass_basic_wing_structure,
-    # )
-    mass_spoilers_and_speedbrakes = 0.015 * mass_basic_wing_structure
+    # high lift mass estimation
+    mass_high_lift_devices = mass_high_lift(
+                                                    wing,
+                                                    max_airspeed_for_flaps,
+                                                    flap_deflection_angle,
+                                                    )
+    # basic wing mass estimation
+    mass_basic_wing = mass_basic_wing_structure(
+                                                    wing,
+                                                    design_mass_TOGW,
+                                                    ultimate_load_factor,
+                                                    suspended_mass,
+                                                    never_exceed_airspeed,
+                                                    main_gear_mounted_to_wing,
+                                                    strut_y_location,
+                                                    )
+    # spoilers and speedbrake estimation
+    mass_spoilers_speedbrakes = mass_spoilers_and_speedbrakes(
+                                                    wing,
+                                                    mass_basic_wing
+                                                    )
 
     mass_wing = (
-            mass_basic_wing_structure +
-            1.2 * (mass_high_lift_devices + mass_spoilers_and_speedbrakes)
+            mass_basic_wing +
+            1.2 * (mass_high_lift_devices + mass_spoilers_speedbrakes)
     )
 
     if return_dict:
         return locals()
     else:
         return mass_wing
+
+
 
 
 # def mass_hstab(


### PR DESCRIPTION
I changed the torenbeek calculations a bit and split the functions for calculating the wing into wing basic structure, high lift and spoilers. The function for the wing mass can be called like before, but it adds the possibility to calculate the high lift and spoilers separately. 

The Design_opt.py from transport aircraft i will be looking at the weight of the basic wing structure more in detail (will come).

Hope this works, had to learn a bit about git and how to provide new code. I will be walking through the stuff and see if I can help where needed.
