### PR TITLE
Update avl.py

### DIFF
--- a/aerosandbox/aerodynamics/aero_3D/avl.py
+++ b/aerosandbox/aerodynamics/aero_3D/avl.py
@@ -557,7 +557,7 @@ class AVL(ExplicitAnalysis):
                 {xsec_def_line}
                 
                 AFIL
-                {af_filepath}
+                {af_filepath.as_posix()}
                 
                 CLAF
                 {claf_line}


### PR DESCRIPTION
Fix the AVL AFIL path to the POSIX format; otherwise, the airfolie data will not be found on Windows computers by AVL.