### PR TITLE
Fix one-character typo in XFoil.alpha() causing TypeError with list input

### DIFF
--- a/aerosandbox/aerodynamics/aero_2D/xfoil.py
+++ b/aerosandbox/aerodynamics/aero_2D/xfoil.py
@@ -652,7 +652,7 @@ class XFoil(ExplicitAnalysis):
             and (np.min(alphas) < start_at < np.max(alphas))
         ):
             alphas_upper = alphas[alphas > start_at]
-            alphas_lower = alphas[alpha <= start_at][::-1]
+            alphas_lower = alphas[alphas <= start_at][::-1]
 
             for a in alphas_upper:
                 schedule_run(a)


### PR DESCRIPTION
Possibly the smallest PR you'll ever review.

`alphas[alpha <= start_at]` on line _**655**_ should be `alphas[alphas <= start_at]`.
The preceding line gets it right; this one missed the rename from `alpha` to `alphas`.

This causes a `TypeError` when `alpha` is passed as a Python list (the default
`start_at=0` triggers the code path), contradicting the docstring which
explicitly allows "a float or an iterable of floats, such as an array".