### PR TITLE
Fix invalid escape sequences in library docstrings

### DIFF
--- a/aerosandbox/library/mass_structural.py
+++ b/aerosandbox/library/mass_structural.py
@@ -78,7 +78,7 @@ def mass_wing_spar(
     ultimate_load_factor=1.75,  # default taken from Daedalus design
     n_booms=1,
 ):
-    """
+    r"""
     Finds the mass of the spar for a wing on a single- or multi-boom lightweight aircraft. Model originally designed for solar aircraft.
     Data was fit to the range 3 < wing_span < 120 [m] and 5 < supported_mass < 3000 [kg], but validity should extend somewhat beyond that.
     Extremely accurate fits within this range; R^2 > 0.995 for all fits.

--- a/aerosandbox/library/propulsion_electric.py
+++ b/aerosandbox/library/propulsion_electric.py
@@ -340,7 +340,7 @@ def mass_motor_electric(
     voltage=20,
     method="hobbyking",
 ):
-    """
+    r"""
     Estimates the mass of a brushless DC electric motor.
     Curve fit to scraped Hobbyking BLDC motor data as of 2/24/2020.
     Estimated range of validity: 50 < max_power < 10000

--- a/aerosandbox/library/propulsion_propeller.py
+++ b/aerosandbox/library/propulsion_propeller.py
@@ -60,7 +60,7 @@ def mass_gearbox(
     rpm_in,
     rpm_out,
 ):
-    """
+    r"""
     Estimates the mass of a gearbox.
 
     Based on data from NASA/TM-2009-215680, available here:

--- a/aerosandbox/library/winds.py
+++ b/aerosandbox/library/winds.py
@@ -5,7 +5,7 @@ import os
 
 
 def wind_speed_conus_summer_99(altitude, latitude):
-    """
+    r"""
     Returns the 99th-percentile wind speed magnitude over the continental United States (CONUS) in July-Aug. Aggregate of data from 1972 to 2019.
     Fits at C:\Projects\GitHub\Wind_Analysis
     :param altitude: altitude [m]


### PR DESCRIPTION
## Summary

Four function docstrings in `aerosandbox/library/` contain literal Windows file paths (e.g.
`C:\Projects\GitHub\...`). Because the docstrings are not raw strings, sequences like `\P`,
`\G`, `\s`, and `\M` are **invalid escape sequences**, which raise `SyntaxWarning` on Python
3.12+ (`DeprecationWarning` on earlier versions) and are slated to become `SyntaxError` in a
future Python release.

This PR marks those four docstrings as raw strings (`r"""`), which silences the warnings
**without changing the rendered docstring text at all**. This mirrors the fix already merged in
#138 (and the existing `r"""` convention elsewhere in the codebase, e.g. `modeling/splines/hermite.py`).

## Files changed

- `aerosandbox/library/mass_structural.py` — `mass_wing_spar` docstring
- `aerosandbox/library/propulsion_electric.py` — `mass_motor_electric` docstring
- `aerosandbox/library/propulsion_propeller.py` — `mass_gearbox` docstring
- `aerosandbox/library/winds.py` — `wind_speed_conus_summer_99` docstring

(4 files, +4/−4: a single `"""` → `r"""` per docstring.)

## Verification

- Compile-time scan of the whole `aerosandbox` package: invalid-escape warnings **4 → 0**.
- AST diff vs `develop`: the extracted docstring text is **byte-identical** before/after (raw
  prefix changes nothing here since the only backslashes are in the literal paths).
- The four modules import cleanly with `invalid escape` warnings promoted to errors; package
  imports and a sample call (`mass_gearbox(...)`) still work.

Targets `develop` per `CONTRIBUTING.md`.
